### PR TITLE
LPD-93905 Show the latest agents and chatbots on the AI Hub homepage

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
@@ -45,8 +45,12 @@ async function getAgentDefinition(externalReferenceCode: string) {
 	return response.json();
 }
 
-async function getAgentDefinitions() {
-	const response = await fetch(AGENT_DEFINITION_BASE_URI, {
+async function getAgentDefinitions(params?: Record<string, string>) {
+	const url = params
+		? `${AGENT_DEFINITION_BASE_URI}?${new URLSearchParams(params)}`
+		: AGENT_DEFINITION_BASE_URI;
+
+	const response = await fetch(url, {
 		method: 'GET',
 	});
 

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService.ts
@@ -17,8 +17,12 @@ const HEADERS = new Headers({
 	'Content-Type': 'application/json',
 });
 
-async function getChatbots() {
-	const response = await fetch(CHATBOT_BASE_URI, {
+async function getChatbots(params?: Record<string, string>) {
+	const url = params
+		? `${CHATBOT_BASE_URI}?${new URLSearchParams(params)}`
+		: CHATBOT_BASE_URI;
+
+	const response = await fetch(url, {
 		headers: HEADERS,
 		method: 'GET',
 	});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard.tsx
@@ -56,7 +56,7 @@ export default function HomeDashboard({
 	useEffect(() => {
 		let isMounted = true;
 
-		getAgentDefinitions()
+		getAgentDefinitions({pageSize: '4', sort: 'dateModified:desc'})
 			.then((data) => {
 				if (isMounted) {
 					setAgents(data?.items ?? []);
@@ -68,7 +68,7 @@ export default function HomeDashboard({
 				}
 			});
 
-		getChatbots()
+		getChatbots({pageSize: '4', sort: 'dateModified:desc'})
 			.then((data) => {
 				if (isMounted) {
 					setChatbots(data?.items ?? []);
@@ -156,7 +156,7 @@ export default function HomeDashboard({
 						title={item.title}
 					/>
 				)}
-				take={3}
+				take={4}
 				title={Liferay.Language.get('latest-chatbots')}
 			/>
 		</div>

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/services/AgentDefinitionService.test.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getAgentDefinitions} from '../../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService';
+
+const mockFetch = jest.fn();
+
+jest.mock('frontend-js-web', () => ({
+	fetch: (...args: any[]) => mockFetch(...args),
+}));
+
+const BASE_URI = '/o/ai-hub/agent-definitions';
+
+describe('AgentDefinitionService', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	describe('getAgentDefinitions', () => {
+		it('targets the base endpoint when no params are given', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+			});
+
+			await getAgentDefinitions();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				BASE_URI,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('appends sort and page size params as a query string', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+			});
+
+			await getAgentDefinitions({
+				pageSize: '4',
+				sort: 'dateModified:desc',
+			});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+	});
+});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/services/ChatbotService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/chatbot_form/services/ChatbotService.test.ts
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getChatbots} from '../../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService';
+
+const mockFetch = jest.fn();
+
+jest.mock('frontend-js-web', () => ({
+	fetch: (...args: any[]) => mockFetch(...args),
+}));
+
+(global as any).Liferay = {
+	ThemeDisplay: {
+		getBCP47LanguageId: () => 'en-US',
+	},
+};
+
+const BASE_URI = '/o/ai-hub/chatbots';
+
+describe('ChatbotService', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	describe('getChatbots', () => {
+		it('targets the base endpoint when no params are given', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+				ok: true,
+			});
+
+			await getChatbots();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				BASE_URI,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('appends sort and page size params as a query string', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+				ok: true,
+			});
+
+			await getChatbots({pageSize: '4', sort: 'dateModified:desc'});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				`${BASE_URI}?pageSize=4&sort=dateModified%3Adesc`,
+				expect.objectContaining({method: 'GET'})
+			);
+		});
+
+		it('throws when the response is not ok', async () => {
+			mockFetch.mockResolvedValueOnce({ok: false});
+
+			await expect(getChatbots()).rejects.toThrow();
+		});
+	});
+});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/home_dashboard/HomeDashboard.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {cleanup, render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import HomeDashboard from '../../../src/main/resources/META-INF/resources/js/home_dashboard/HomeDashboard';
+
+const mockGetAgentDefinitions = jest.fn();
+const mockGetChatbots = jest.fn();
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService',
+	() => ({
+		getAgentDefinitions: (...args: any[]) =>
+			mockGetAgentDefinitions(...args),
+	})
+);
+
+jest.mock(
+	'../../../src/main/resources/META-INF/resources/js/chatbot_form/services/ChatbotService',
+	() => ({
+		getChatbots: (...args: any[]) => mockGetChatbots(...args),
+	})
+);
+
+(global as any).Liferay = {
+	Icons: {spritemap: 'icons.svg'},
+	Language: {
+		get: (key: string) => key,
+	},
+};
+
+const defaultProps = {
+	agentBuilderURL: '/agent-builder',
+	agentURL: '/agent',
+	backURL: '/back',
+	chatbotURL: '/chatbot',
+	chatbotsURL: '/chatbots',
+};
+
+function buildItems(prefix: string, count: number) {
+	return Array.from({length: count}, (_, index) => ({
+		active: true,
+		externalReferenceCode: `${prefix}_${index}`,
+		title: `${prefix} ${index}`,
+	}));
+}
+
+describe('HomeDashboard', () => {
+	beforeEach(() => {
+		mockGetAgentDefinitions.mockReset();
+		mockGetChatbots.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('requests the latest agents and chatbots sorted by modification date', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({items: []});
+		mockGetChatbots.mockResolvedValue({items: []});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(mockGetAgentDefinitions).toHaveBeenCalledWith({
+				pageSize: '4',
+				sort: 'dateModified:desc',
+			});
+		});
+
+		expect(mockGetChatbots).toHaveBeenCalledWith({
+			pageSize: '4',
+			sort: 'dateModified:desc',
+		});
+	});
+
+	it('renders up to four chatbots in the order returned by the server', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({items: []});
+		mockGetChatbots.mockResolvedValue({items: buildItems('Chatbot', 5)});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Chatbot 0')).toBeInTheDocument();
+		});
+
+		expect(screen.getByText('Chatbot 1')).toBeInTheDocument();
+		expect(screen.getByText('Chatbot 2')).toBeInTheDocument();
+		expect(screen.getByText('Chatbot 3')).toBeInTheDocument();
+		expect(screen.queryByText('Chatbot 4')).not.toBeInTheDocument();
+	});
+
+	it('renders up to four agents', async () => {
+		mockGetAgentDefinitions.mockResolvedValue({
+			items: buildItems('Agent', 5),
+		});
+		mockGetChatbots.mockResolvedValue({items: []});
+
+		render(<HomeDashboard {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Agent 0')).toBeInTheDocument();
+		});
+
+		expect(screen.getByText('Agent 3')).toBeInTheDocument();
+		expect(screen.queryByText('Agent 4')).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93905

## What Is Being Fixed

On the AI Hub homepage, the "Latest Agents" and "Latest Chatbots" lists did not show the most recent entries. The agents list was never sorted by modification date, so newly created or duplicated agents never appeared and it always showed the same oldest four. The chatbots list had the same sorting problem (oldest to latest) and additionally capped its display at three items instead of four.

## How It Is Being Fixed

The homepage requested both lists from their REST endpoints without a sort or page size and then sliced the first few entries on the client, which returned them in creation order. The fix passes query parameters so the server returns the entries already sorted by modification date in descending order and limited to a page size of four. The `getAgentDefinitions` and `getChatbots` services now accept an optional params argument that is appended as a query string, leaving their existing callers unchanged. The chatbots section's display limit was also corrected from three to four to match the agents section.

## PR Check

**pr-check: PASS** — tested on `31839c68d75d24d0e66522a69edc91c38549b130`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "31839c68d75d24d0e66522a69edc91c38549b130"} -->